### PR TITLE
[PLAT-2704] Allow setting heapdump directory

### DIFF
--- a/files/CASSANDRA-9822/cassandra
+++ b/files/CASSANDRA-9822/cassandra
@@ -80,7 +80,6 @@ do_start()
     ulimit -n "$FD_LIMIT"
 
     cassandra_home=`getent passwd cassandra | awk -F ':' '{ print $6; }'`
-    heap_dump_f="$cassandra_home/java_`date +%s`.hprof"
     error_log_f="$cassandra_home/hs_err_`date +%s`.log"
 
     [ -e `dirname "$PIDFILE"` ] || \
@@ -91,7 +90,7 @@ do_start()
     start-stop-daemon -S -c cassandra -a /usr/sbin/cassandra -q -p "$PIDFILE" -t >/dev/null || return 1
 
     start-stop-daemon -S -c cassandra -a /usr/sbin/cassandra -b -p "$PIDFILE" -- \
-        -p "$PIDFILE" -H "$heap_dump_f" -E "$error_log_f" >/dev/null || return 2
+        -p "$PIDFILE" -E "$error_log_f" >/dev/null || return 2
 
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ class cassandra (
   $fail_on_non_supported_os                             = true,
   $fail_on_non_suppoted_os                              = undef,
   $file_cache_size_in_mb                                = undef,
+  $heap_dump_directory                                  = undef,
   $hinted_handoff_enabled                               = true,
   $hinted_handoff_throttle_in_kb                        = 1024,
   $hints_directory                                      = undef,


### PR DESCRIPTION
The Debian Cassandra package includes an init script which hardcodes the
heapdump location to be within the Cassandra home directory, regardless
of what is specified in `-XX:HeapDumpPath`.

We need to move our heapdumps into the ephemeral disk so we don't run
out of space on our root EBS volumes.

Luckily, the Cassandra Puppet module already patches the default init
script to work around another Cassandra packaging bug, so we can easily
patch the patch.

Our patch removes the hard coding of this path, allowing the option to
be set using the `CASSANDRA_HEAPDUMP_DIR` environment variable, which is
then used by `cassandra-env.sh` to set the `-XX:HeapDumpPath` option.