### PR TITLE
Make the auth caches configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,9 +106,12 @@ class cassandra (
   $package_name                                         = $::cassandra::params::cassandra_pkg,
   $partitioner
     = 'org.apache.cassandra.dht.Murmur3Partitioner',
-  $permissions_cache_max_size                           = 1000,
+  $permissions_cache_max_entries                        = 1000,
   $permissions_update_interval_in_ms                    = undef,
   $permissions_validity_in_ms                           = 2000,
+  $roles_cache_max_entries                              = 1000,
+  $roles_update_interval_in_ms                          = undef,
+  $roles_validity_in_ms                                 = 2000,
   $phi_convict_threshold                                = undef,
   $prefer_local                                         = undef,
   $rack                                                 = 'RAC1',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class cassandra (
   $package_name                                         = $::cassandra::params::cassandra_pkg,
   $partitioner
     = 'org.apache.cassandra.dht.Murmur3Partitioner',
+  $permissions_cache_max_size                           = 1000,
   $permissions_update_interval_in_ms                    = undef,
   $permissions_validity_in_ms                           = 2000,
   $phi_convict_threshold                                = undef,

--- a/spec/classes/cassandra_spec.rb
+++ b/spec/classes/cassandra_spec.rb
@@ -114,6 +114,7 @@ describe 'cassandra' do
         'package_ensure' => 'present',
         'package_name' => 'cassandra22',
         'partitioner' => 'org.apache.cassandra.dht.Murmur3Partitioner',
+        'permissions_cache_max_entries' => 1000,
         'permissions_validity_in_ms' => 2000,
         # 'prefer_local' => nil,
         'rack' => 'RAC1',

--- a/spec/classes/cassandra_spec.rb
+++ b/spec/classes/cassandra_spec.rb
@@ -116,6 +116,8 @@ describe 'cassandra' do
         'partitioner' => 'org.apache.cassandra.dht.Murmur3Partitioner',
         'permissions_cache_max_entries' => 1000,
         'permissions_validity_in_ms' => 2000,
+        'roles_cache_max_entries' => 1000,
+        'roles_validity_in_ms' => 2000,
         # 'prefer_local' => nil,
         'rack' => 'RAC1',
         'rackdc_tmpl' => 'cassandra/cassandra-rackdc.properties.erb',

--- a/templates/cassandra.yaml.erb
+++ b/templates/cassandra.yaml.erb
@@ -77,7 +77,7 @@ authenticator: <%= @authenticator %>
 authorizer: <%= @authorizer %>
 
 # Max number of entries allowed in the permissions cache.
-permissions_cache_max_size: <%= @permissions_cache_max_size %>
+permissions_cache_max_entries: <%= @permissions_cache_max_entries %>
 
 # Validity period for permissions cache (fetching permissions can be an
 # expensive operation depending on the authorizer, CassandraAuthorizer is
@@ -92,6 +92,18 @@ permissions_validity_in_ms: <%= @permissions_validity_in_ms %>
 # also.
 # Defaults to the same value as permissions_validity_in_ms.
 <% if @permissions_update_interval_in_ms != nil %>permissions_update_interval_in_ms: <%= @permissions_update_interval_in_ms %><% else %># permissions_update_interval_in_ms: 1000<% end %>
+
+# Maximum number of entries allowed in the roles cache.
+roles_cache_max_entries: <%= @roles_cache_max_entries %>
+
+# Validity period for the roles cache (fetching roles can be an
+# expensive operation depending on the hierarchy). 
+# Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+roles_validity_in_ms: <%= @roles_validity_in_ms %>
+
+# Refresh interval for roles cache (if enabled).
+<% if @roles_update_interval_in_ms != nil %>roles_update_interval_in_ms: <%= @roles_update_interval_in_ms %><% else %># roles_update_interval_in_ms: 1000<% end %>
 
 # The partitioner is responsible for distributing groups of rows (by
 # partition key) across nodes in the cluster.  You should leave this

--- a/templates/cassandra.yaml.erb
+++ b/templates/cassandra.yaml.erb
@@ -76,6 +76,9 @@ authenticator: <%= @authenticator %>
 #   increase system_auth keyspace replication factor if you use this authorizer.
 authorizer: <%= @authorizer %>
 
+# Max number of entries allowed in the permissions cache.
+permissions_cache_max_size: <%= @permissions_cache_max_size %>
+
 # Validity period for permissions cache (fetching permissions can be an
 # expensive operation depending on the authorizer, CassandraAuthorizer is
 # one example). Defaults to 2000, set to 0 to disable.


### PR DESCRIPTION
**Make the permissions cache max size configurable**

We will do C* credential rotation through Vault and we will have a
credential pair per pod with permissions on the service keyspace.

If permissions are not stored in the cache, queries need to check
the system_auth keyspace (overhead of an extra query). We want to
allow configuration of the cache size to ensure it can hold all
permissions for all credentials, to avoid churn and overhead.

**Configure roles cache similar to permissions cache**
See https://github.com/apache/cassandra/blob/b32a9e6452c78e6ad08e371314bf1ab7492d0773/src/java/org/apache/cassandra/config/DatabaseDescriptor.java

There are no configuration options for the credentials cache, it
doesn't seem to be used in C* 3.0.15.

https://github.com/apache/cassandra/tree/b32a9e6452c78e6ad08e371314bf1ab7492d0773/src/java/org/apache/cassandra/auth