### PR TITLE
Update apt dependency version tolerance

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-firewall",


### PR DESCRIPTION
We've tested this module with much later versions of `puppet-apt`, so this updates the version requirements to allow this (and should resolve dependency warnings).