### PR TITLE
Backport fixes for open files and directory permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class cassandra (
   $fail_on_non_suppoted_os                              = undef,
   $file_cache_size_in_mb                                = undef,
   $heap_dump_directory                                  = undef,
+  $heap_dump_directory_mode                             = '0750',
   $hinted_handoff_enabled                               = true,
   $hinted_handoff_throttle_in_kb                        = 1024,
   $hints_directory                                      = undef,
@@ -337,6 +338,17 @@ class cassandra (
 
   cassandra::private::data_directory { $data_file_directories: }
 
+  if ! defined( File[$heap_dump_directory] ) {
+    file { $heap_dump_directory:
+      ensure  => directory,
+      owner   => 'cassandra',
+      group   => 'cassandra',
+      mode    => $heap_dump_directory_mode,
+      require => $data_dir_require,
+      before  => $data_dir_before,
+    }
+  }
+
   if ! defined( File[$saved_caches_directory] ) {
     file { $saved_caches_directory:
       ensure  => directory,
@@ -358,6 +370,7 @@ class cassandra (
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],
+          File[$heap_dump_directory],
           File[$saved_caches_directory],
           File[$dc_rack_properties_file],
           Package['cassandra'],
@@ -372,6 +385,7 @@ class cassandra (
           File[$commitlog_directory],
           File[$config_file],
           File[$data_file_directories],
+          File[$heap_dump_directory],
           File[$saved_caches_directory],
           File[$dc_rack_properties_file],
           Package['cassandra'],

--- a/templates/cassandra.service.erb
+++ b/templates/cassandra.service.erb
@@ -10,7 +10,7 @@ ExecStart=/etc/init.d/<%= @service_name %> start
 ExecStop=/etc/init.d/<%= @service_name %> stop
 StandardOutput=journal
 StandardError=journal
-LimitNOFILE=100000
+LimitNOFILE=250000
 LimitMEMLOCK=infinity
 LimitNPROC=32768
 LimitAS=infinity

--- a/templates/cassandra.yaml.erb
+++ b/templates/cassandra.yaml.erb
@@ -38,7 +38,7 @@ hinted_handoff_enabled: <%= @hinted_handoff_enabled %>
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
-max_hint_window_in_ms: <%= @max_hint_window_in_ms %> # 3 hours
+max_hint_window_in_ms: <%= @max_hint_window_in_ms %>
 # Maximum throttle in KBs per second, per delivery thread.  This will be
 # reduced proportionally to the number of nodes in the cluster.  (If there
 # are two nodes in the cluster, each delivery thread will use the maximum

--- a/templates/cassandra1.yaml.erb
+++ b/templates/cassandra1.yaml.erb
@@ -41,7 +41,7 @@ hinted_handoff_enabled: <%= @hinted_handoff_enabled %>
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
-max_hint_window_in_ms: <%= @max_hint_window_in_ms %> # 3 hours
+max_hint_window_in_ms: <%= @max_hint_window_in_ms %>
 # Maximum throttle in KBs per second, per delivery thread.  This will be
 # reduced proportionally to the number of nodes in the cluster.  (If there
 # are two nodes in the cluster, each delivery thread will use the maximum

--- a/templates/cassandra20.yaml.erb
+++ b/templates/cassandra20.yaml.erb
@@ -39,7 +39,7 @@ hinted_handoff_enabled: <%= @hinted_handoff_enabled %>
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
-max_hint_window_in_ms: <%= @max_hint_window_in_ms %> # 3 hours
+max_hint_window_in_ms: <%= @max_hint_window_in_ms %>
 # Maximum throttle in KBs per second, per delivery thread.  This will be
 # reduced proportionally to the number of nodes in the cluster.  (If there
 # are two nodes in the cluster, each delivery thread will use the maximum


### PR DESCRIPTION
Backports a couple of fixes from @lyubent and @suhailpatel:

- remove an incorrect comment on max hints
- ensure the heap_dump directory is created with the correct permissions
- bump open file limit to 250k